### PR TITLE
Fixup/v0.1.0 4

### DIFF
--- a/lustre/handshake/init.lua
+++ b/lustre/handshake/init.lua
@@ -42,6 +42,11 @@ function Handshake:send(socket, url, host)
   req:add_header("Sec-Websocket-Version", 13)
   req:add_header("Sec-Websocket-Key", self.key)
   req:add_header("Host", host)
+
+  for key, val in pairs(self.extra_headers) do
+    req:add_header(key, val)
+  end
+  
   if next(self.protocols) then
     req:add_header("Sec-Websocket-Protocol",
       table.concat(self.protocols, ","))

--- a/lustre/utils.lua
+++ b/lustre/utils.lua
@@ -1,4 +1,5 @@
 local log = require"log"
+log.trace = function(...) end
 
 local U8_AS_I8 = {
   [0] = 0,
@@ -465,7 +466,7 @@ end
 
 local function valid_4_byte_set(one, two, three,
   four)
-  -- (0xF0, 0x90..=0xBF) 
+  -- (0xF0, 0x90..=0xBF)
   if one == 0xF0 then
     return two >= 0x90 and two <= 0xBF
              and trailer_is_in_range(three)

--- a/lustre/ws.lua
+++ b/lustre/ws.lua
@@ -14,6 +14,9 @@ local CloseCode =
   require"lustre.frame.close".CloseCode
 local Message = require"lustre.message"
 local log = require"log"
+-- disable debugging logs
+log.debug = function(...) end
+log.trace = function(...) end
 
 local utils = require"lustre.utils"
 

--- a/lustre/ws.lua
+++ b/lustre/ws.lua
@@ -156,6 +156,28 @@ function WebSocket:send(message)
 end
 
 ---@return number, string|nil
+function WebSocket:client_handshake_and_start(host, port)
+  if not self.is_client then -- todo use metatables to enforce this
+    log.error(self.id, "Invalid client websocket")
+    return nil, "only a client can connect"
+  end
+  -- Do handshake
+  log.debug(self.id, "sending handshake")
+  local success, err = self.handshake:send(
+    self.socket, self.url,
+    string.format("%s:%d", host, port))
+  log.debug(self.id, "handshake complete",
+    success or err)
+  if not success then
+    return nil, "invalid handshake: " .. err
+  end
+  cosock.spawn(function()
+    self:_receive_loop()
+  end, "Client receive loop")
+  return 1
+end
+
+---@return number, string|nil
 function WebSocket:connect(host, port)
   log.trace(self.id, "WebSocket:connect", host,
     port)
@@ -174,20 +196,7 @@ function WebSocket:connect(host, port)
     return nil, "socket connect failure: " .. err
   end
 
-  -- Do handshake
-  log.debug(self.id, "sending handshake")
-  local success, err = self.handshake:send(
-    self.socket, self.url,
-    string.format("%s:%d", host, port))
-  log.debug(self.id, "handshake complete",
-    success or err)
-  if not success then
-    return nil, "invalid handshake: " .. err
-  end
-  cosock.spawn(function()
-    self:_receive_loop()
-  end, "Client receive loop")
-  return 1
+  return self:client_handshake_and_start(host, port)
 end
 
 function WebSocket:accept()
@@ -205,6 +214,7 @@ function WebSocket:close(close_code, reason)
     local close_frame = Frame.close(close_code,
       reason):set_mask() -- TODO client vs server
     local tx, reply = cosock.channel.new()
+    reply:settimeout(0.5)
     log.debug("sending frame to socket task")
     local suc, err = self._send_tx:send(
       {frame = close_frame, reply = tx})
@@ -214,7 +224,9 @@ function WebSocket:close(close_code, reason)
       return nil, "channel error:" .. err
     end
     log.debug("waiting on reply")
-    return reply:receive()
+    local reply = reply:receive()
+    log.debug("reply received")
+    return reply
   elseif self.state == "ClosedBySelf" then
     self.state = "CloseAcknowledged"
   end
@@ -274,7 +286,9 @@ function WebSocket:_receive_loop()
   end
   log.debug("Closing socket")
   self.socket:close()
+  log.debug("Closing channel")
   self._send_rx:close()
+  log.debug("Channel closed")
 end
 
 function WebSocket:_handle_recvs(state, recv, idx)
@@ -322,7 +336,7 @@ function WebSocket:_handle_recv_ready(state)
     Frame.from_stream(self.socket)
   log.debug(self.id, "build frame", frame or err)
   if not frame then
-    log.info("error building frame", err)
+    log.debug("error building frame", err)
     if err == "invalid opcode" or err
       == "invalid rsv bit" then
       log.warn(self.id,
@@ -581,10 +595,18 @@ function WebSocket:_handle_send_ready()
     local closed = err:match("close")
     if closed and self.state == "Active" then
       log.debug("closed error", err)
-      reply:send({err = err})
+      if reply and reply.send then
+        reply:send({err = err})
+      else
+        log.error(string.format("No reply channel in event for progating error: %s", err))
+      end
     end
     if not closed then
-      reply:send({err = err})
+      if reply and reply.send then
+        reply:send({err = err})
+      else
+        log.error(string.format("No reply channel in event for progating error: %s", err))
+      end
     end
     return
   end


### PR DESCRIPTION
During usage of this library in the SmartThings sonos edge [driver](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/tree/main/drivers/SmartThings/sonos/src/lustre), @dljsjr discovered a few fixes that were needed for the library to work properly for that use case. This PR is upstreaming those changes:

1. An api was needed for creating a WebSocket table from an already connected socket f693866ecd5449e6cd7c264b34c79f1c1ddc369f
2. A timeout was needed when sending the close frame to prevent blocking f693866ecd5449e6cd7c264b34c79f1c1ddc369f
3. Extra headers were not being sent during handshakes a26532d7c6f7358b58fd1b989642ce2e8d365928
4. Debug logging needed to be silenced.